### PR TITLE
Add additional info enpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ be written.
 ## Informational
 
 * `getConfig` gets the system-level Flink configuration.
+* `getClusterOverview` gets the Flink cluster information.
+* `getJobManagerConfig` gets all the JobManager configurations.
+* `getClusterTaskManagers` gets the information about all the TaskManagers inside the Flink cluster.
 
 # Credits
 

--- a/api/src/main/scala/com/github/mjreid/flinkwrapper/ClusterTaskManagers.scala
+++ b/api/src/main/scala/com/github/mjreid/flinkwrapper/ClusterTaskManagers.scala
@@ -1,0 +1,45 @@
+package com.github.mjreid.flinkwrapper
+
+import java.time.LocalDateTime
+
+import com.github.mjreid.flinkwrapper.util.Readers
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+case class ClusterTaskManagers(
+  taskManagers: Seq[TaskManager]
+)
+
+object ClusterTaskManagers {
+  implicit val reads: Reads[ClusterTaskManagers] =
+    (JsPath \ "taskmanagers").read[Seq[TaskManager]]
+      .map(tm => ClusterTaskManagers(tm))
+}
+
+case class TaskManager(
+  id: String,
+  path: String,
+  dataPort: Int,
+  timeSinceLastHeartbeat: LocalDateTime,
+  slotsNumber: Int,
+  freeSlots: Int,
+  cpuCores: Int,
+  physicalMemory: Long,
+  freeMemory: Long,
+  managedMemory: Long
+)
+
+object TaskManager {
+  implicit val reads: Reads[TaskManager] = (
+    (JsPath \ "id").read[String] and
+      (JsPath \ "path").read[String] and
+      (JsPath \ "dataPort").read[Int] and
+      (JsPath \ "timeSinceLastHeartbeat").read[LocalDateTime](Readers.millisLocalDateTimeReader) and
+      (JsPath \ "slotsNumber").read[Int] and
+      (JsPath \ "freeSlots").read[Int] and
+      (JsPath \ "cpuCores").read[Int] and
+      (JsPath \ "physicalMemory").read[Long] and
+      (JsPath \ "freeMemory").read[Long] and
+      (JsPath \ "managedMemory").read[Long]
+    )(TaskManager.apply _)
+}

--- a/api/src/main/scala/com/github/mjreid/flinkwrapper/FlinkClusterOverview.scala
+++ b/api/src/main/scala/com/github/mjreid/flinkwrapper/FlinkClusterOverview.scala
@@ -1,0 +1,26 @@
+package com.github.mjreid.flinkwrapper
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+
+case class FlinkClusterOverview(
+  taskManagers: Int,
+  totalSlots: Int,
+  availableSlots: Int,
+  runningJobs: Int,
+  finishedJobs: Int,
+  cancelledJobs: Int,
+  failedJobs: Int
+)
+
+object FlinkClusterOverview {
+  implicit val reads: Reads[FlinkClusterOverview] = (
+    (JsPath \ "taskmanagers").read[Int] and
+      (JsPath \ "slots-total").read[Int] and
+      (JsPath \ "slots-available").read[Int] and
+      (JsPath \ "jobs-running").read[Int] and
+      (JsPath \ "jobs-finished").read[Int] and
+      (JsPath \ "jobs-cancelled").read[Int] and
+      (JsPath \ "jobs-failed").read[Int]
+    )(FlinkClusterOverview.apply _)
+}

--- a/api/src/main/scala/com/github/mjreid/flinkwrapper/FlinkConfig.scala
+++ b/api/src/main/scala/com/github/mjreid/flinkwrapper/FlinkConfig.scala
@@ -1,0 +1,13 @@
+package com.github.mjreid.flinkwrapper
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+
+case class FlinkConfig(key: String, value: String)
+
+object FlinkConfig {
+  implicit val reads: Reads[FlinkConfig] = (
+    (JsPath \ "key").read[String] and
+      (JsPath \ "value").read[String]
+    )(FlinkConfig.apply _)
+}

--- a/api/src/main/scala/com/github/mjreid/flinkwrapper/FlinkConfigInfo.scala
+++ b/api/src/main/scala/com/github/mjreid/flinkwrapper/FlinkConfigInfo.scala
@@ -24,12 +24,3 @@ object FlinkConfigInfo {
     )(FlinkConfigInfo.apply _)
 }
 
-case class FlinkClusterOverview(
-  taskManagers: Int,
-  totalSlots: Int,
-  availableSlots: Int,
-  runningJobs: Int,
-  finishedJobs: Int,
-  cancelledJobs: Int,
-  failedJobs: Int
-)

--- a/api/src/main/scala/com/github/mjreid/flinkwrapper/FlinkRestClient.scala
+++ b/api/src/main/scala/com/github/mjreid/flinkwrapper/FlinkRestClient.scala
@@ -37,6 +37,26 @@ class FlinkRestClient(flinkRestClientConfig: FlinkRestClientConfig) extends Auto
   }
 
   /**
+    * getClusterOverview returns the overiview of the Flink cluster.
+    */
+  def getClusterOverview()(implicit ec: ExecutionContext): Future[FlinkClusterOverview] = {
+    wsClient.url(url + "overview").get().map(responseHandler.handleResponse[FlinkClusterOverview])
+  }
+  /**
+    * getJobManagerConfig returns the job manager configurations of the Flink server.
+    */
+  def getJobManagerConfig()(implicit ec: ExecutionContext): Future[Seq[FlinkConfig]] = {
+    wsClient.url(url + "jobmanager/config").get().map(responseHandler.handleResponse[Seq[FlinkConfig]])
+  }
+
+  /**
+    * getClusterTaskManagers gets a list of all task managers.
+    */
+  def getClusterTaskManagers()(implicit ec: ExecutionContext): Future[ClusterTaskManagers] = {
+    wsClient.url(url + "taskmanagers").get().map(responseHandler.handleResponse[ClusterTaskManagers])
+  }
+
+  /**
     * getJobsList gets a list of all jobs, separated by the state of each job.
     */
   def getJobsList()(implicit ec: ExecutionContext): Future[JobsList] = {

--- a/api/src/main/scala/com/github/mjreid/flinkwrapper/FlinkRestClient.scala
+++ b/api/src/main/scala/com/github/mjreid/flinkwrapper/FlinkRestClient.scala
@@ -37,7 +37,7 @@ class FlinkRestClient(flinkRestClientConfig: FlinkRestClientConfig) extends Auto
   }
 
   /**
-    * getClusterOverview returns the overiview of the Flink cluster.
+    * getClusterOverview returns the overview of the Flink cluster.
     */
   def getClusterOverview()(implicit ec: ExecutionContext): Future[FlinkClusterOverview] = {
     wsClient.url(url + "overview").get().map(responseHandler.handleResponse[FlinkClusterOverview])


### PR DESCRIPTION
This PR aim to cover the following endpoints to have additional cluster information:
* `/overview`: show some informations about the cluster activity
* `/taskmanagers`: show some informations about the TaskManagers (for example memory and task slot usage)
* `/jobmanager/config`: show the cluster configurations